### PR TITLE
#41 - Auto claim status sync in safe data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safient/core",
-  "version": "0.1.8-alpha",
+  "version": "0.1.9-alpha",
   "description": "JavaScript SDK to manage safes and interact with Safient protocol.",
   "keywords": [
     "Web3",

--- a/src/SafientCore.ts
+++ b/src/SafientCore.ts
@@ -465,9 +465,15 @@ export class SafientCore {
     try {  
       const result: Safe = await getSafeData(safeId);
       // TODO: Need to move the different function
-      // if(result.decSafeKeyShards.length >=2 && result.stage !== SafeStages.CLAIMED){
-      //    result.stage = SafeStages.RECOVERED
-      // }
+      if(result.stage === SafeStages.CLAIMING){
+        const claimStatus = await this.getClaimStatus(safeId, result.claims[result.claims.length - 1].disputeId)
+        result.claims[result.claims.length - 1].claimStatus = claimStatus
+        if(claimStatus === ClaimStages.PASSED){
+          result.stage = SafeStages.RECOVERING
+        }else{
+          result.stage = SafeStages.ACTIVE
+        }
+      }
       return new SafientResponse({data: result});
     } catch (err) {
       throw new SafientResponse({error: Errors.SafeNotFound})
@@ -633,7 +639,9 @@ export class SafientCore {
       const indexValue = safe.guardians.indexOf(did);
       let recoveryStatus: boolean = false;
       // internal function 
-      if (safe.stage === SafeStages.RECOVERING) {
+      const res = await this.syncStage(safeId)
+
+      if (res.data === true && safe.stage === SafeStages.RECOVERING) {
         const decShard: DecShard = await this.connection.idx?.ceramic.did?.decryptDagJWE(
           safe.encSafeKeyShards[indexValue].data
         ) as DecShard;

--- a/src/SafientCore.ts
+++ b/src/SafientCore.ts
@@ -747,7 +747,11 @@ export class SafientCore {
           await this.updateStage(safeId, ClaimStages.PASSED, SafeStages.CLAIMED);
           result = JSON.parse(safeData.toString());
           return new SafientResponse({data: result.data})
-        } else {
+        }else if(safeData !== undefined && safe.stage === SafeStages.CLAIMED){
+          result = JSON.parse(safeData.toString());
+          return new SafientResponse({data: result.data})
+        } 
+        else {
           throw new SafientResponse({error: Errors.StageNotUpdated})
         }
       }

--- a/test/scenario1.js
+++ b/test/scenario1.js
@@ -224,10 +224,10 @@ describe('Scenario 1 - Creating safe offChain', async () => {
     expect(result.data).to.equal(true);
   });
 
-  it('Should update the stage on threadDB', async () => {
-    const result = await beneficiarySc.syncStage(safeId);
-    expect(result.data).to.equal(true);
-  });
+  // it('Should update the stage on threadDB', async () => {
+  //   const result = await beneficiarySc.syncStage(safeId);
+  //   expect(result.data).to.equal(true);
+  // });
 
   it('Should initiate recovery by guardian 1', async () => {
     const data = await guardianOneSc.reconstructSafe(safeId, guardianOne.data.did);

--- a/test/scenario2.js
+++ b/test/scenario2.js
@@ -244,10 +244,10 @@ describe('Scenario 2 - Creating safe onChain and Failing the dispute', async () 
     expect(result.data).to.equal(true);
   });
 
-  it('Should update the stage on threadDB', async () => {
-    const result = await beneficiarySc.syncStage(safeId);
-    expect(result.data).to.equal(true);
-  });
+  // it('Should update the stage on threadDB', async () => {
+  //   const result = await beneficiarySc.syncStage(safeId);
+  //   expect(result.data).to.equal(true);
+  // });
 
   it('Should try to create Claim 2', async () => {
     const file = {
@@ -264,10 +264,10 @@ describe('Scenario 2 - Creating safe onChain and Failing the dispute', async () 
     expect(result.data).to.equal(true);
   });
 
-  it('Should update the stage on threadDB', async () => {
-    const result = await beneficiarySc.syncStage(safeId);
-    expect(result.data).to.equal(true);
-  });
+  // it('Should update the stage on threadDB', async () => {
+  //   const result = await beneficiarySc.syncStage(safeId);
+  //   expect(result.data).to.equal(true);
+  // });
 
   it('Should initiate recovery by guardian 1', async () => {
     const data = await guardianOneSc.reconstructSafe(safeId, guardianOne.data.did);

--- a/test/scenario3.js
+++ b/test/scenario3.js
@@ -231,12 +231,12 @@ describe('Scenario 3 - Creating safe onChain and Passed the dispute', async () =
     });
   });
 
-  describe('Sync safe stage', async () => {
-    it('Updates the safe stage on threadDB according to the ruling', async () => {
-      const result = await beneficiarySc.syncStage(safeId);
-      expect(result.data).to.equal(true);
-    });
-  });
+  // describe('Sync safe stage', async () => {
+  //   it('Updates the safe stage on threadDB according to the ruling', async () => {
+  //     const result = await beneficiarySc.syncStage(safeId);
+  //     expect(result.data).to.equal(true);
+  //   });
+  // });
 
   describe('Guardian recovery', async () => {
     it('Recovery done by guardian 1', async () => {

--- a/test/scenario4.js
+++ b/test/scenario4.js
@@ -240,10 +240,10 @@ describe('Scenario 4 - Creating signal based Safe', async () => {
     expect(disputeId.data).to.be.a('number');
   });
 
-  it('Should update the stage on threadDB', async () => {
-    const result = await beneficiarySc.syncStage(safeId);
-    expect(result.data).to.equal(true);
-  });
+  // it('Should update the stage on threadDB', async () => {
+  //   const result = await beneficiarySc.syncStage(safeId);
+  //   expect(result.data).to.equal(true);
+  // });
 
   it('Should initiate recovery by guardian 1', async () => {
     const data = await guardianOneSc.reconstructSafe(safeId, guardianOne.data.did);

--- a/test/scenario5.js
+++ b/test/scenario5.js
@@ -221,10 +221,10 @@ describe('Scenario 5 - Creating signal based Safe', async () => {
     expect(result.data.status).to.equal(1);
   });
 
-  it('Should update the stage on threadDB', async () => {
-    const result = await beneficiarySc.syncStage(safeId);
-    expect(result.data).to.equal(true);
-  });
+  // it('Should update the stage on threadDB', async () => {
+  //   const result = await beneficiarySc.syncStage(safeId);
+  //   expect(result.data).to.equal(true);
+  // });
 
   it('Should try recovery by guardian 1', async () => {
     const data = await guardianOneSc.reconstructSafe(safeId, guardianOne.data.did);

--- a/test/scenario6.js
+++ b/test/scenario6.js
@@ -313,10 +313,10 @@ describe('Scenario 6 - Creating DDay based Safe', async () => {
     expect(claimResult).to.equal(1); // claim got Passed (after D-Day)
   });
 
-  it('Should update the stage on threadDB', async () => {
-    const result = await beneficiarySc.syncStage(safeId);
-    expect(result.data).to.equal(true);
-  });
+  // it('Should update the stage on threadDB', async () => {
+  //   const result = await beneficiarySc.syncStage(safeId);
+  //   expect(result.data).to.equal(true);
+  // });
 
   it('Should initiate recovery by guardian 1', async () => {
     const data = await guardianOneSc.reconstructSafe(safeId, guardianOne.data.did);

--- a/test/unitTest.js
+++ b/test/unitTest.js
@@ -231,10 +231,10 @@ describe('Unit test', async () => {
     expect(result.data).to.equal(true);
   });
 
-  it('Should update the stage on threadDB', async () => {
-    const result = await beneficiarySc.syncStage(safeId);
-    expect(result.data).to.equal(true);
-  });
+  // it('Should update the stage on threadDB', async () => {
+  //   const result = await beneficiarySc.syncStage(safeId);
+  //   expect(result.data).to.equal(true);
+  // });
 
   // //Step 4: Recover Safes
 


### PR DESCRIPTION
## Description:

This PR adds an internal auto syncing of claim stages without the beneficiary doing it previously.


## Modified:

List the modified features
* `getSafe` returns the updated claim stage if the safe is in `Claiming` stage
* `reconstructSafe` syncs the claim stage we called. 
